### PR TITLE
Add respository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:pthm/slack-webhook.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pthm/slack-webhook/issues"
+  },
+  "homepage": "https://github.com/pthm/slack-webhook",
   "author": "Patt-tom McDonnell",
   "license": "MIT"
 }


### PR DESCRIPTION
Adds repository information to package json so potential contributors can find the github repo from the npm page.
