### PR TITLE
Add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.travis.yml
+test


### PR DESCRIPTION
Just realized I forgot to add an `.npmignore` file.

Before

``` bash
$ npm pack
$ tar -tf slack-webhook-1.0.0.tgz
package/package.json
package/.npmignore
package/README.md
package/index.js
package/lib/merge.js
package/lib/request.js
package/test/helper.js
package/test/index.test.js
package/test/merge.test.js
package/test/request.test.js
```

After

``` bash
$ npm pack
$ tar -tf slack-webhook-1.0.0.tgz
package/package.json
package/.npmignore
package/README.md
package/index.js
package/lib/merge.js
package/lib/request.js
```
